### PR TITLE
For Rails 5 upgrade: Avoid deprecated Fixnum and Bignum

### DIFF
--- a/lib/serialized_attr_accessors.rb
+++ b/lib/serialized_attr_accessors.rb
@@ -105,8 +105,8 @@ module SerializedAttrAccessors
           unless field_value.nil?
             if [true, false].include?(field_value)
               field_value = field_value
-            elsif (field_value.is_a?(Fixnum) or field_value.is_a?(Bignum)) #Todo: Use a regexp instead
-              field_value = ((field_value.to_i <= 0) ? false : true)
+            elsif field_value.is_a?(Integer)
+              field_value = field_value > 0
             elsif field_value.is_a?(String)
               temp_f = field_value.downcase.strip
               field_value = if temp_f == "false"

--- a/serialized_attr_accessors.gemspec
+++ b/serialized_attr_accessors.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = "serialized_attr_accessors"
-  s.version = "1.0.2"
-  s.date = '2020-12-01'
+  s.version = "1.0.3"
+  s.date = '2021-03-04'
   s.summary = "DEPRECATED: SerializedAttrAccessors generates multiple attr_accessors in a Rails mode. Consolidates them to a single, serialized column per-model"
   s.description = "Deprecated: Attribute accessor generator using 'sattr_accessor' to add 'pseudo-columns' to a model. Consolidates multiple attributes to a single columner per-model. Default storage column is :serialized_options, or a different serialized field using `for_serialized_field` with ablock."
   s.authors = ["Praveen Kumar Sinha", "Mike Bijon NRS", "Michal Kracik NRS"]


### PR DESCRIPTION
Actually started in Ruby 2.4, was filling logs with irrelevant warnings similar to those from Rails.